### PR TITLE
Y3-210 > Apps CLI > As a developer I can install app

### DIFF
--- a/lib/cli/commands/apps/create.ts
+++ b/lib/cli/commands/apps/create.ts
@@ -42,7 +42,7 @@ export default function command(_cli: CLI): CommandDefinition {
           description: 'Your package description',
           main: 'index.js',
           scripts: {
-            start: 'node index.js && youcan apps:install',
+            start: `node index.js && youcan apps:install -n ${app.name}`,
           },
           dependencies: {},
         };

--- a/lib/cli/commands/apps/create.ts
+++ b/lib/cli/commands/apps/create.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import prompts from 'prompts';
 import type { PromptObject } from 'prompts';
 import type { CLI, CommandDefinition } from '@/cli/commands/types';
@@ -11,13 +12,10 @@ export default function command(_cli: CLI): CommandDefinition {
     name: 'apps:create',
     group: 'apps',
     description: 'Create your app',
-
     action: async () => {
       if (!cli.client.isAuthenticated())
         return stdout.error(messages.AUTH_USER_NOT_LOGGED_IN);
-
       const loading = new LoadingSpinner('Creating your app ...');
-
       try {
         const inquiries: PromptObject[] = [
           {
@@ -27,11 +25,37 @@ export default function command(_cli: CLI): CommandDefinition {
             validate: value => value !== '' && value.length > 3,
           },
         ];
-
         const app = await prompts(inquiries);
-
         loading.start();
         await cli.client.createApp({ name: app.name });
+
+        const appPath = `./${app.name}`;
+
+        fs.mkdir(appPath, (err: any) => {
+          if (err)
+            loading.error(`Error creating directory: ${err}`);
+        });
+
+        const packageContent = {
+          name: app.name,
+          version: '0.0.1',
+          description: 'Your package description',
+          main: 'index.js',
+          scripts: {
+            start: 'node index.js && youcan apps:install',
+          },
+          dependencies: {},
+        };
+
+        fs.writeFile(`${appPath}/package.json`, JSON.stringify(packageContent, null, 2), (err: any) => {
+          if (err)
+            stdout.error(`Error creating the package.json file: ${err}`);
+        });
+
+        fs.writeFile(`${appPath}/index.js`, 'console.log(\'Hello, World!\')', (err: any) => {
+          if (err)
+            stdout.error(`Error creating the index.js file: ${err}`);
+        });
 
         loading.stop();
       }
@@ -42,4 +66,3 @@ export default function command(_cli: CLI): CommandDefinition {
     },
   };
 }
-

--- a/lib/cli/commands/apps/install.ts
+++ b/lib/cli/commands/apps/install.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import type { CLI, CommandDefinition } from '@/cli/commands/types';
+import stdout from '@/utils/system/stdout';
+import messages from '@/config/messages';
+import cli from '@/cli';
+
+export default function command(_cli: CLI): CommandDefinition {
+  return {
+    name: 'apps:install',
+    group: 'apps',
+    description: 'Generate app installation url',
+
+    action: async () => {
+      if (!cli.client.isAuthenticated())
+        return stdout.error(messages.AUTH_USER_NOT_LOGGED_IN);
+      try {
+        fs.readFile('package.json', 'utf8', async (err, data) => {
+          if (err) {
+            stdout.error(`Error reading package.json:${err}`);
+            return;
+          }
+
+          const packageData = JSON.parse(data);
+          const appName = packageData.name;
+
+          const response = await cli.client.generateAppInstallationUrl(appName);
+          stdout.info(`To test the app within your store hit the following url : ${response.url}`);
+        });
+      }
+      catch (err: any) {
+        const error = JSON.parse(err.message);
+        stdout.error(error);
+      }
+    },
+  };
+}
+

--- a/lib/cli/commands/apps/install.ts
+++ b/lib/cli/commands/apps/install.ts
@@ -9,23 +9,16 @@ export default function command(_cli: CLI): CommandDefinition {
     name: 'apps:install',
     group: 'apps',
     description: 'Generate app installation url',
+    options: [
+      { name: '-n, --name <app>', description: 'Specify a app name e.g. codmanager' },
+    ],
 
-    action: async () => {
+    action: async (options: Record<string, string>) => {
       if (!cli.client.isAuthenticated())
         return stdout.error(messages.AUTH_USER_NOT_LOGGED_IN);
       try {
-        fs.readFile('package.json', 'utf8', async (err, data) => {
-          if (err) {
-            stdout.error(`Error reading package.json:${err}`);
-            return;
-          }
-
-          const packageData = JSON.parse(data);
-          const appName = packageData.name;
-
-          const response = await cli.client.generateAppInstallationUrl(appName);
-          stdout.info(`To test the app within your store hit the following url : ${response.url}`);
-        });
+        const response = await cli.client.generateAppInstallationUrl(options.name);
+        stdout.info(`To test the app within your store hit the following url : ${response.url}`);
       }
       catch (err: any) {
         const error = JSON.parse(err.message);

--- a/lib/cli/commands/index.ts
+++ b/lib/cli/commands/index.ts
@@ -16,3 +16,4 @@ export { default as StoreSwitchCommand } from './store/switch';
 
 // apps
 export { default as CreateAppCommand } from './apps/create';
+export { default as InstallAppCommand } from './apps/install';

--- a/lib/core/client/client.ts
+++ b/lib/core/client/client.ts
@@ -3,7 +3,7 @@ import { FormData } from 'formdata-node';
 import type { RequestInit } from 'node-fetch';
 import { mergeDeepLeft } from 'ramda';
 import fetch from 'node-fetch';
-import type { CreateAppRequest, CreateAppResponse, DeleteThemeFileRequestData, InitThemeRequest as InitThemeRequestData, InitThemeResponse, LoginRequest, LoginResponse, SelectStoreRequest, SelectStoreResponse, StoreInfoResponse, ThemeMetaResponse, UpdateThemeFileRequestData } from './types';
+import type { CreateAppRequest, CreateAppResponse, DeleteThemeFileRequestData, GenerateAppInstallationUrlResponse, InitThemeRequest as InitThemeRequestData, InitThemeResponse, LoginRequest, LoginResponse, SelectStoreRequest, SelectStoreResponse, StoreInfoResponse, ThemeMetaResponse, UpdateThemeFileRequestData } from './types';
 import { get, post } from '@/utils/http';
 import config from '@/config';
 import { delay } from '@/utils/common';
@@ -105,8 +105,15 @@ export default class Client {
     Object.entries(data).forEach(([key, value]) => form.append(key, value));
 
     return await post<CreateAppResponse>(
-      `${config.SELLER_AREA_API_BASE_URI}/apps/create`,
+      `${config.SELLER_AREA_API_BASE_URI}/apps/draft/create`,
       this.withDefaults({ body: form }),
+    );
+  }
+
+  public async generateAppInstallationUrl(name: string): Promise<GenerateAppInstallationUrlResponse> {
+    return await get<GenerateAppInstallationUrlResponse>(
+      `${config.SELLER_AREA_API_BASE_URI}/apps/draft/generate-installation-url?name=${name}`,
+      this.withDefaults(),
     );
   }
 

--- a/lib/core/client/types.ts
+++ b/lib/core/client/types.ts
@@ -88,3 +88,7 @@ export interface CreateAppRequest {
 export interface CreateAppResponse {
   name: string
 }
+
+export interface GenerateAppInstallationUrlResponse {
+  url: string
+}


### PR DESCRIPTION
## JIRA Ticket

[DOT-210](https://youcanshop.atlassian.net/browse/DOT-210)

## Note

Now when a user creates an app we generate an app folder with a `package.json` file within this file containing the app name then when the user runs `npm start` we provide an app installation URL

## QA Steps

* [ ] First you should point on the local CLI project update the URLs on `lib/config/index.ts`
* [ ] Then Change the the agent import from `https` to `http`
* [ ] Checkout [Y3-210](https://github.com/youcan-shop/youcanmono/pull/7290) on youcanmono
* [ ] Run `youcan apps:create` Then enter the app name `codmanager` for example
* [ ] On the app folder run `npm start` you should be able to see the app installation URL like 
<img width="1474" alt="image" src="https://github.com/youcan-shop/cli/assets/68709410/d58d3a97-9585-4f91-ae17-0c62911e4314">


[DOT-210]: https://youcanshop.atlassian.net/browse/DOT-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[Y3-210]: https://youcanshop.atlassian.net/browse/Y3-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ