### PR TITLE
DARK: Themes > Ignore user created folders inside default theme dirs

### DIFF
--- a/packages/cli-kit/lib/node/filesystem.ts
+++ b/packages/cli-kit/lib/node/filesystem.ts
@@ -21,6 +21,17 @@ export async function exists(path: string): Promise<boolean> {
   }
 }
 
+export async function isDirectory(path: string): Promise<boolean> {
+  try {
+    const stats: Stats = await FilesystemPromises.stat(path);
+
+    return stats.isDirectory();
+  }
+  catch {
+    return false;
+  }
+}
+
 export async function tapIntoTmp<T>(callback: (tmp: string) => T | Promise<T>): Promise<T> {
   return temporaryDirectoryTask(callback);
 }

--- a/packages/theme/lib/cli/commands/theme/dev.ts
+++ b/packages/theme/lib/cli/commands/theme/dev.ts
@@ -53,6 +53,13 @@ export default class Dev extends ThemeCommand {
             }
 
             for (const file of present.filter(f => !descriptors.find(d => d.file_name === f))) {
+              const path = Path.resolve(directory, file);
+              const stats = await Filesystem.stat(path);
+
+              if (stats.isDirectory()) {
+                continue;
+              }
+
               await execute(theme, 'save', type, file);
             }
 

--- a/packages/theme/lib/cli/commands/theme/dev.ts
+++ b/packages/theme/lib/cli/commands/theme/dev.ts
@@ -54,9 +54,9 @@ export default class Dev extends ThemeCommand {
 
             for (const file of present.filter(f => !descriptors.find(d => d.file_name === f))) {
               const path = Path.resolve(directory, file);
-              const stats = await Filesystem.stat(path);
+              const isDir = await Filesystem.isDirectory(path);
 
-              if (stats.isDirectory()) {
+              if (isDir) {
                 continue;
               }
 
@@ -65,7 +65,7 @@ export default class Dev extends ThemeCommand {
 
             for (const descriptor of descriptors) {
               const path = Path.resolve(directory, descriptor.file_name);
-              if (!(await Filesystem.exists(path))) {
+              if ((await Filesystem.isDirectory(path)) || !(await Filesystem.exists(path))) {
                 return await execute(theme, 'delete', type, descriptor.file_name);
               }
 

--- a/packages/theme/lib/cli/services/dev/worker.ts
+++ b/packages/theme/lib/cli/services/dev/worker.ts
@@ -51,6 +51,7 @@ export default class ThemeWorker extends Worker.Abstract {
       awaitWriteFinish: { stabilityThreshold: 50 },
       ignoreInitial: true,
       persistent: true,
+      depth: 0,
     });
 
     this.command.controller.signal.addEventListener('abort', () => {


### PR DESCRIPTION
## JIRA Ticket

DARK

## QA Steps

* [ ] `cd` into the `cli` folder.
* [ ] Link the cli package globally `pnpm -g link`.
* [ ] Go the the `/themes` repo (Make sure it's cloned).
* [ ] Link the `cli` package with it.
* [ ] `cd` into one of the themes (Aura for example).
* [ ] Create a directory **_inside_** one of the directories `/sections/foo` for example.
* [ ] Run `pnpm dev`.
* [ ] The command should fail with an EISDIR error: `illegal operation on a directory, read`.
* [ ] Checkout to this PR's branch.
* [ ] run `pnpm build`.
* [ ] Go back to Aura.
* [ ] run `pnpm dev`.
* [ ] The command should continue normally.

## Note

Leave empty when you have nothing to say
