### PR TITLE
APPS-7 : Automatically detect package manager and install dependencies on init

### DIFF
--- a/packages/cli-kit/lib/node/system.ts
+++ b/packages/cli-kit/lib/node/system.ts
@@ -95,21 +95,21 @@ export async function open(url: string): Promise<void> {
 export type PackageManagerType =
   | 'pnpm'
   | 'npm'
-  | 'yarn'
+  | 'yarn';
 
-export function inferUserPackageManager(): PackageManagerType { 
-    const defaultPackageManager = 'npm';
-    const packageManagersMap: Record<string, PackageManagerType> = {
+export function inferUserPackageManager(): PackageManagerType {
+  const defaultPackageManager = 'npm';
+  const packageManagersMap: Record<string, PackageManagerType> = {
     '^npm/.*': 'npm',
     '^pnpm/.*': 'pnpm',
     '^yarn/.*': 'yarn',
   };
 
-  let packageManagerUserAgent = process.env['npm_config_user_agent'] as string;
+  const packageManagerUserAgent = process.env.npm_config_user_agent as string;
 
   for (const key in packageManagersMap) {
     if (new RegExp(key).test(packageManagerUserAgent)) {
-        return packageManagersMap[key];
+      return packageManagersMap[key];
     }
   }
 

--- a/packages/cli-kit/lib/node/system.ts
+++ b/packages/cli-kit/lib/node/system.ts
@@ -18,7 +18,6 @@ export interface ExecOptions {
 
 function buildExec(command: string, args: string[], options?: ExecOptions): ExecaChildProcess<string> {
   const env = options?.env ?? process.env;
-  
   const commandProcess = execa(command, args, {
     env,
     cwd: options?.cwd,
@@ -98,20 +97,20 @@ export type PackageManagerType =
   | 'yarn'
 
 export function inferUserPackageManager(): PackageManagerType { 
-    const defaultPm = 'npm';
-    const pmsMap: Record<string, PackageManagerType> = {
+    const defaultPackageManager = 'npm';
+    const packageManagersMap: Record<string, PackageManagerType> = {
     '^npm/.*': 'npm',
     '^pnpm/.*': 'pnpm',
     '^yarn/.*': 'yarn',
   };
 
-  let pmUserAgent = process.env['npm_config_user_agent'] as string;
+  let packageManagerUserAgent = process.env['npm_config_user_agent'] as string;
 
-  for (const key in pmsMap) {
-    if (new RegExp(key).test(pmUserAgent)) {
-        return pmsMap[key];
+  for (const key in packageManagersMap) {
+    if (new RegExp(key).test(packageManagerUserAgent)) {
+        return packageManagersMap[key];
     }
   }
 
-  return defaultPm;
+  return defaultPackageManager;
 }

--- a/packages/cli-kit/lib/node/system.ts
+++ b/packages/cli-kit/lib/node/system.ts
@@ -18,6 +18,7 @@ export interface ExecOptions {
 
 function buildExec(command: string, args: string[], options?: ExecOptions): ExecaChildProcess<string> {
   const env = options?.env ?? process.env;
+  
   const commandProcess = execa(command, args, {
     env,
     cwd: options?.cwd,
@@ -89,4 +90,28 @@ export async function open(url: string): Promise<void> {
   const _open = await import('open');
 
   await _open.default(url);
+}
+
+export type PackageManagerType =
+  | 'pnpm'
+  | 'npm'
+  | 'yarn'
+
+export function inferUserPackageManager(): PackageManagerType { 
+    const defaultPm = 'npm';
+    const pmsMap: Record<string, PackageManagerType> = {
+    '^npm/.*': 'npm',
+    '^pnpm/.*': 'pnpm',
+    '^yarn/.*': 'yarn',
+  };
+
+  let pmUserAgent = process.env['npm_config_user_agent'] as string;
+
+  for (const key in pmsMap) {
+    if (new RegExp(key).test(pmUserAgent)) {
+        return pmsMap[key];
+    }
+  }
+
+  return defaultPm;
 }

--- a/packages/cli-kit/lib/node/system.ts
+++ b/packages/cli-kit/lib/node/system.ts
@@ -34,6 +34,7 @@ function buildExec(command: string, args: string[], options?: ExecOptions): Exec
 
 export async function exec(command: string, args: string[], options?: ExecOptions): Promise<void> {
   const commandProcess = buildExec(command, args, options);
+
   if (options?.stderr && options.stderr !== 'inherit') {
     commandProcess.stderr?.pipe(options.stderr, { end: false });
   }

--- a/packages/cli-kit/lib/node/tasks.ts
+++ b/packages/cli-kit/lib/node/tasks.ts
@@ -27,11 +27,12 @@ export async function run<T = unknown>(ctx: T, tasks: Task<T>[]): Promise<T> {
           await runTask(subtask, ctx);
         }
       }
-    }
+    };
 
     if (task.loadable === false) {
       process.stdout.write(`${task.title}\n`);
       await runner();
+
       return ctx;
     }
 

--- a/packages/create-app/bin/exec.js
+++ b/packages/create-app/bin/exec.js
@@ -5,4 +5,4 @@ process.removeAllListeners('warning');
 // eslint-disable-next-line import/first
 import execCreateAppCli from '../dist/index.js';
 
-execCreateAppCli(true);
+execCreateAppCli(false);

--- a/packages/create-app/bin/exec.js
+++ b/packages/create-app/bin/exec.js
@@ -5,4 +5,4 @@ process.removeAllListeners('warning');
 // eslint-disable-next-line import/first
 import execCreateAppCli from '../dist/index.js';
 
-execCreateAppCli(false);
+execCreateAppCli(true);

--- a/packages/create-app/lib/commands/init.ts
+++ b/packages/create-app/lib/commands/init.ts
@@ -4,6 +4,25 @@ import { Cli, Path } from '@youcan/cli-kit';
 import initPrompt from '@/prompts/init';
 import initService from '@/services/init';
 
+function inferUsedPackageManager(): string
+{
+  const pmsMap = {
+    'x': 'npm',
+    'y': 'yarn',
+    'z': 'yarn',
+    'default': 'npm'
+  };
+
+  const packageManger = process.env['npm_execpath'] ?? 'default';
+
+  console.log(process.env);
+
+  process.exit(1);
+  
+
+  return 'ok';
+}
+
 export default class Init extends Cli.Command {
   static aliases: string[] = ['create-app'];
   static description = 'bootstraps a new youcan app';
@@ -20,6 +39,7 @@ export default class Init extends Cli.Command {
   };
 
   public async run(): Promise<void> {
+    console.log(inferUsedPackageManager());
     const { flags } = await this.parse(Init);
     const response = await initPrompt(this);
 
@@ -30,11 +50,13 @@ export default class Init extends Cli.Command {
       this.log('Operation cancelled');
       this.exit(130);
     }
+    
 
     await initService(this, {
       name: response.name,
       directory: flags.path,
       template: response.template,
+      packageManager: 'pnpm'
     });
   }
 }

--- a/packages/create-app/lib/commands/init.ts
+++ b/packages/create-app/lib/commands/init.ts
@@ -1,27 +1,8 @@
 import { cwd } from 'process';
 import { Flags } from '@oclif/core';
-import { Cli, Path } from '@youcan/cli-kit';
+import { Cli, Path, System } from '@youcan/cli-kit';
 import initPrompt from '@/prompts/init';
 import initService from '@/services/init';
-
-function inferUsedPackageManager(): string
-{
-  const pmsMap = {
-    'x': 'npm',
-    'y': 'yarn',
-    'z': 'yarn',
-    'default': 'npm'
-  };
-
-  const packageManger = process.env['npm_execpath'] ?? 'default';
-
-  console.log(process.env);
-
-  process.exit(1);
-  
-
-  return 'ok';
-}
 
 export default class Init extends Cli.Command {
   static aliases: string[] = ['create-app'];
@@ -39,7 +20,6 @@ export default class Init extends Cli.Command {
   };
 
   public async run(): Promise<void> {
-    console.log(inferUsedPackageManager());
     const { flags } = await this.parse(Init);
     const response = await initPrompt(this);
 
@@ -50,13 +30,12 @@ export default class Init extends Cli.Command {
       this.log('Operation cancelled');
       this.exit(130);
     }
-    
 
     await initService(this, {
       name: response.name,
       directory: flags.path,
       template: response.template,
-      packageManager: 'pnpm'
+      packageManager: System.inferUserPackageManager(),
     });
   }
 }

--- a/packages/create-app/lib/services/init.ts
+++ b/packages/create-app/lib/services/init.ts
@@ -14,7 +14,7 @@ async function initService(command: Cli.Command, options: InitServiceOptions) {
 
   const slug = String.hyphenate(options.name);
   const outdir = Path.join(options.directory, slug);
-  const relativeOutDir = path.relative(process.cwd(), outdir);
+  const relativeOutdir = path.relative(process.cwd(), outdir);
 
   await assertDirectoryAvailability(outdir, slug);
 
@@ -53,15 +53,16 @@ async function initService(command: Cli.Command, options: InitServiceOptions) {
         },
       },
       {
-        title: `Copying files to ${relativeOutDir}...`,
+        title: `Copying files to ${relativeOutdir}...`,
         task: async () => {
           await Filesystem.move(templateDownloadDirectory, outdir);
         },
       },
       {
         title: `Installing dependencies...`,
+        loadable: false,
         task: async () => {
-          await System.exec('npm', ['install', '--no-progress'], {
+          await System.exec(options.packageManager, ['install'], {
             stdout: 'inherit',
             stderr: 'inherit',
             cwd: outdir,
@@ -75,7 +76,7 @@ async function initService(command: Cli.Command, options: InitServiceOptions) {
   command.output.info('   Developer Docs: https://developer.youcan.shop\n\n');
 
   command.output.info('   To preview your app, run');
-  command.output.info(`      cd ${relativeOutDir}`);
+  command.output.info(`      cd ${relativeOutdir}`);
   command.output.info('      pnpm dev');
   command.output.info('   For an overview of all the command, run `pnpm youcan app help`');
 }

--- a/packages/create-app/lib/services/init.ts
+++ b/packages/create-app/lib/services/init.ts
@@ -1,17 +1,16 @@
+import path from 'path';
 import type { Cli } from '@youcan/cli-kit';
 import { Filesystem, Git, Github, Path, String, System, Tasks } from '@youcan/cli-kit';
-import { inferUserPackageManager } from '@youcan/cli-kit/dist/node/system';
-import path from 'path';
+import type { inferUserPackageManager } from '@youcan/cli-kit/dist/node/system';
 
 interface InitServiceOptions {
   name: string
   directory: string
-  template?: string,
+  template?: string
   packageManager: ReturnType<typeof inferUserPackageManager>
 }
 
 async function initService(command: Cli.Command, options: InitServiceOptions) {
-
   const slug = String.hyphenate(options.name);
   const outdir = Path.join(options.directory, slug);
   const relativeOutdir = path.relative(process.cwd(), outdir);
@@ -59,7 +58,7 @@ async function initService(command: Cli.Command, options: InitServiceOptions) {
         },
       },
       {
-        title: `Installing dependencies...`,
+        title: 'Installing dependencies...',
         loadable: false,
         task: async () => {
           await System.exec(options.packageManager, ['install'], {
@@ -77,7 +76,7 @@ async function initService(command: Cli.Command, options: InitServiceOptions) {
 
   command.output.info('   To preview your app, run');
   command.output.info(`      cd ${relativeOutdir}`);
-  command.output.info('      pnpm dev');
+  command.output.info(`      ${options.packageManager} dev`);
   command.output.info('   For an overview of all the command, run `pnpm youcan app help`');
 }
 

--- a/packages/create-app/lib/services/init.ts
+++ b/packages/create-app/lib/services/init.ts
@@ -1,10 +1,16 @@
 import type { Cli } from '@youcan/cli-kit';
 import { Filesystem, Git, Github, Path, String, Tasks } from '@youcan/cli-kit';
 
+type PackageManagersType =
+  | 'pnpm'
+  | 'npm'
+  | 'yarn'
+
 interface InitServiceOptions {
   name: string
   directory: string
-  template?: string
+  template?: string,
+  packageManager: PackageManagersType
 }
 
 async function initService(command: Cli.Command, options: InitServiceOptions) {


### PR DESCRIPTION
## JIRA Ticket

[APPS-7](https://youcanshop.atlassian.net/browse/APPS-7)

I could not get this pr to be tested perfectly locally, so to qa it well, we need to follow some steps.

To know the package manager used by the user, I used this env var `npm_config_user_agent` that all package managers set. to know what each one of theme puts in it, we need to:
## Steps
* [ ] Start a process with a package manager of choice `npm`, `pnpm` or `yarn`, (eg, `pnpm init @youcan/create-app`)
* [ ] Find the pid of the process, (`ps aux | grep create-app`)
* [ ] Inspect its env variables and look for `npm_config_user_agent`, (`ps -Eww | grep <PID> | tr ' ' '\n' | grep npm_config_user_agent`)
* [ ] Make a note of it's value you might want to use the other package managers too.

## QA Steps
* [ ] Run
```
npm_config_user_agent={value_retrieved} {path_to_cloned_repo}/cli/packages/create-app/bin/exec.js
```
* [ ] Follow the steps and see see the node_module is installed.

## Note
 - <del> I am using --no-progress option for `npm install` , bc it messes up the out put, it might be fixed, but still to figure it out if wanted.</del>
 - There are changes that are personal preferences; don't hesitate to disagree
 - The `Installing dependencies...` task seems out of style, to think of a better way to handle unloadable tasks.

[APPS-7]: https://youcanshop.atlassian.net/browse/APPS-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ