### PR TITLE
CORE-805: linked env configs

### DIFF
--- a/packages/app/lib/cli/commands/app/config/link.ts
+++ b/packages/app/lib/cli/commands/app/config/link.ts
@@ -1,0 +1,66 @@
+import type { RemoteAppConfig, RemoteAppSummary } from '@/types';
+import { Args, Flags } from '@oclif/core';
+import { Color, Env, Filesystem, Http, Path, Session } from '@youcan/cli-kit';
+import { appConfigFilename } from '@/constants';
+import { AppCommand } from '@/util/app-command';
+
+export default class ConfigLink extends AppCommand {
+  static description = 'Create a config file linked to a remote app';
+
+  static args = {
+    env: Args.string({ required: true, description: 'Environment name, writes youcan.app.<env>.json' }),
+  };
+
+  static flags = {
+    app: Flags.string({ description: 'App id or handle, prompts when omitted' }),
+  };
+
+  async run() {
+    const { args, flags } = await this.parse(ConfigLink);
+
+    if (!/^[a-z0-9-]+$/.test(args.env)) {
+      this.output.error('Environment names may only contain lowercase letters, digits, and dashes.');
+    }
+
+    this.session = await Session.authenticate(this);
+
+    const key = flags.app ?? await this.promptForApp();
+    const remote = await Http.get<RemoteAppConfig>(`${Env.apiHostname()}/apps/${key}`);
+
+    const filename = appConfigFilename(args.env);
+
+    await Filesystem.writeJsonFile(Path.resolve(Path.cwd(), filename), {
+      name: remote.name,
+      id: remote.id,
+      handle: remote.handle,
+      app_url: remote.app_url,
+      redirect_urls: remote.redirect_urls,
+      oauth: {
+        scopes: remote.scopes,
+        client_id: remote.client_id,
+      },
+    });
+
+    this.log();
+    this.log(`${Color.green('[OK]')} ${Color.cyan(filename)} linked to ${remote.name} (${remote.id}).`);
+    this.log(`     Use it with ${Color.cyan(`--config ${args.env}`)} on dev, deploy, release, and versions.`);
+    this.log();
+  }
+
+  private async promptForApp(): Promise<string> {
+    const { apps } = await Http.get<{ apps: RemoteAppSummary[] }>(`${Env.apiHostname()}/apps`);
+
+    if (!apps.length) {
+      this.output.error('You have no apps yet, run `youcan app dev` to create one.');
+    }
+
+    const response = await this.prompt({
+      type: 'select',
+      name: 'app',
+      message: 'Which app should this config point at?',
+      choices: apps.map(app => ({ title: `${app.name} (${app.handle})`, value: app.id })),
+    });
+
+    return response.app;
+  }
+}

--- a/packages/app/lib/cli/commands/app/config/pull.ts
+++ b/packages/app/lib/cli/commands/app/config/pull.ts
@@ -1,15 +1,16 @@
 import type { AppConfig, AppVersion, Manifest } from '@/types';
 import { Color, Env, Filesystem, Http, Path, Session } from '@youcan/cli-kit';
-import { APP_CONFIG_FILENAME } from '@/constants';
 import { AppCommand } from '@/util/app-command';
 import { load } from '@/util/app-loader';
 
 export default class ConfigPull extends AppCommand {
-  static description = 'Update youcan.app.json from the active released version';
+  static description = 'Update the app config file from the active released version';
 
   async run() {
+    const { flags } = await this.parse(ConfigPull);
+
     this.session = await Session.authenticate(this);
-    this.app = await load();
+    this.app = await load(flags.config);
 
     if (!this.app.config.id) {
       this.output.error('This app has no remote counterpart yet, run `youcan app dev` first.');
@@ -23,7 +24,7 @@ export default class ConfigPull extends AppCommand {
       return this.output.error('This app has no active version yet, run `youcan app deploy` to create one.');
     }
 
-    const path = Path.join(this.app.root, APP_CONFIG_FILENAME);
+    const path = Path.join(this.app.root, this.app.configFilename);
     const disk = await Filesystem.readJsonFile<AppConfig>(path);
     const config = version.manifest.app;
 
@@ -41,7 +42,7 @@ export default class ConfigPull extends AppCommand {
     });
 
     this.log();
-    this.log(`${Color.green('[OK]')} ${Color.cyan(APP_CONFIG_FILENAME)} synced from version ${version.name} (#${version.version}).`);
+    this.log(`${Color.green('[OK]')} ${Color.cyan(this.app.configFilename)} synced from version ${version.name} (#${version.version}).`);
     this.log();
   }
 }

--- a/packages/app/lib/cli/commands/app/deploy.ts
+++ b/packages/app/lib/cli/commands/app/deploy.ts
@@ -21,7 +21,7 @@ export default class Deploy extends AppCommand {
     const { flags } = await this.parse(Deploy);
 
     this.session = await Session.authenticate(this);
-    this.app = await load();
+    this.app = await load(flags.config);
 
     if (!this.app.config.id) {
       this.output.error('This app has no remote counterpart yet, run `youcan app dev` first.');

--- a/packages/app/lib/cli/commands/app/dev.ts
+++ b/packages/app/lib/cli/commands/app/dev.ts
@@ -22,6 +22,7 @@ class Dev extends AppCommand {
   };
 
   private workers: Worker.Interface[] = [];
+  private configEnv?: string;
   private hasWebWorker = false;
   private useTunnel = false;
 
@@ -110,8 +111,9 @@ class Dev extends AppCommand {
 
   async run(): Promise<any> {
     const { flags } = await this.parse(Dev);
+    this.configEnv = flags.config;
     this.session = await Session.authenticate(this);
-    this.app = await load();
+    this.app = await load(this.configEnv);
 
     this.hasWebWorker = this.app.webs.length > 0;
     this.useTunnel = this.hasWebWorker && !flags['no-tunnel'];
@@ -155,7 +157,7 @@ class Dev extends AppCommand {
       this.workers = [];
     }
 
-    this.app = await load();
+    this.app = await load(this.configEnv);
 
     const webWorkers = this.hasWebWorker ? await this.bootWebWorkers() : [];
 

--- a/packages/app/lib/cli/commands/app/env/pull.ts
+++ b/packages/app/lib/cli/commands/app/env/pull.ts
@@ -1,8 +1,8 @@
+import { Flags } from '@oclif/core';
+import { Color, Filesystem, Path, Session, Tasks } from '@youcan/cli-kit';
 import { getAppEnvironmentVariables } from '@/cli/services/environment-variables';
 import { AppCommand } from '@/util/app-command';
 import { load } from '@/util/app-loader';
-import { Flags } from '@oclif/core';
-import { Color, Filesystem, Path, Session, Tasks, UI } from '@youcan/cli-kit';
 
 class EnvPull extends AppCommand {
   static description = 'Create or update a .env file with app environment variables';
@@ -18,13 +18,17 @@ class EnvPull extends AppCommand {
     const { flags } = await this.parse(EnvPull);
     const envFilePath = Path.resolve(flags['env-file']);
 
-    this.app = await load();
+    this.app = await load(flags.config);
     this.session = await Session.authenticate(this);
+
+    if (!this.app.config.id) {
+      this.output.error('This app has no remote counterpart yet, run `youcan app dev` first.');
+    }
 
     await Tasks.run({}, [
       {
-        title: 'Syncing app configuration..',
-        task: async () => { await this.syncAppConfig(); },
+        title: 'Fetching app configuration..',
+        task: async () => { await this.fetchRemoteConfig(); },
       },
     ]);
 

--- a/packages/app/lib/cli/commands/app/env/show.ts
+++ b/packages/app/lib/cli/commands/app/env/show.ts
@@ -1,19 +1,25 @@
+import { Color, Session, Tasks } from '@youcan/cli-kit';
 import { getAppEnvironmentVariables } from '@/cli/services/environment-variables';
 import { AppCommand } from '@/util/app-command';
 import { load } from '@/util/app-loader';
-import { Color, Env, Session, Tasks } from '@youcan/cli-kit';
 
 class EnvShow extends AppCommand {
   static description = 'Display app environment variables';
 
   async run(): Promise<any> {
-    this.app = await load();
+    const { flags } = await this.parse(EnvShow);
+
+    this.app = await load(flags.config);
     this.session = await Session.authenticate(this);
+
+    if (!this.app.config.id) {
+      this.output.error('This app has no remote counterpart yet, run `youcan app dev` first.');
+    }
 
     await Tasks.run({}, [
       {
-        title: 'Syncing app configuration..',
-        task: async () => { await this.syncAppConfig(); },
+        title: 'Fetching app configuration..',
+        task: async () => { await this.fetchRemoteConfig(); },
       },
     ]);
 

--- a/packages/app/lib/cli/commands/app/generate/extension.ts
+++ b/packages/app/lib/cli/commands/app/generate/extension.ts
@@ -1,9 +1,9 @@
 import type { AppConfig, InitialAppConfig } from '@/types';
+import { Filesystem, Path, String, Tasks } from '@youcan/cli-kit';
 import extensions from '@/cli/services/generate/extensions';
 import { ensureExtensionDirectoryExists, initThemeExtension } from '@/cli/services/generate/generate';
 import { APP_CONFIG_FILENAME } from '@/constants';
 import { AppCommand } from '@/util/app-command';
-import { Filesystem, Path, String, Tasks } from '@youcan/cli-kit';
 
 class GenerateExtension extends AppCommand {
   static description = 'Generate an app extension';

--- a/packages/app/lib/cli/commands/app/install.ts
+++ b/packages/app/lib/cli/commands/app/install.ts
@@ -1,6 +1,6 @@
+import { Env, Http, Session, System, Tasks } from '@youcan/cli-kit';
 import { AppCommand } from '@/util/app-command';
 import { load } from '@/util/app-loader';
-import { Env, Http, Session, System, Tasks } from '@youcan/cli-kit';
 
 export default class Install extends AppCommand {
   static description = 'Generate an app installation URL';

--- a/packages/app/lib/cli/commands/app/release.ts
+++ b/packages/app/lib/cli/commands/app/release.ts
@@ -15,7 +15,7 @@ export default class Release extends AppCommand {
     const { flags } = await this.parse(Release);
 
     this.session = await Session.authenticate(this);
-    this.app = await load();
+    this.app = await load(flags.config);
 
     if (!this.app.config.id) {
       this.output.error('This app has no remote counterpart yet, run `youcan app dev` first.');

--- a/packages/app/lib/cli/commands/app/versions.ts
+++ b/packages/app/lib/cli/commands/app/versions.ts
@@ -7,8 +7,10 @@ export default class Versions extends AppCommand {
   static description = 'List the app versions';
 
   async run() {
+    const { flags } = await this.parse(Versions);
+
     this.session = await Session.authenticate(this);
-    this.app = await load();
+    this.app = await load(flags.config);
 
     if (!this.app.config.id) {
       this.output.error('This app has no remote counterpart yet, run `youcan app dev` first.');

--- a/packages/app/lib/cli/services/deploy/manifest.test.ts
+++ b/packages/app/lib/cli/services/deploy/manifest.test.ts
@@ -13,6 +13,7 @@ describe('buildManifest', () => {
   const app = (): App => ({
     root,
     webs: [],
+    configFilename: 'youcan.app.json',
     extensions: [
       {
         root: path.join(root, 'extensions', 'rating'),

--- a/packages/app/lib/cli/services/dev/workers/app-worker.test.ts
+++ b/packages/app/lib/cli/services/dev/workers/app-worker.test.ts
@@ -1,6 +1,6 @@
 import type DevCommand from '@/cli/commands/app/dev';
 import type { App } from '@/types';
-import { Filesystem, Path, Worker } from '@youcan/cli-kit';
+import { Filesystem, Path } from '@youcan/cli-kit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AppWorker from './app-worker';
 
@@ -51,6 +51,7 @@ describe('appWorker', () => {
 
     mockApp = {
       root: '/path/to/app',
+      configFilename: 'youcan.app.json',
     } as App;
 
     appWorker = new AppWorker(mockCommand, mockApp);

--- a/packages/app/lib/cli/services/dev/workers/app-worker.ts
+++ b/packages/app/lib/cli/services/dev/workers/app-worker.ts
@@ -1,6 +1,5 @@
 import type DevCommand from '@/cli/commands/app/dev';
 import type { App } from '@/types';
-import { APP_CONFIG_FILENAME } from '@/constants';
 import { Filesystem, Path, Worker } from '@youcan/cli-kit';
 
 export default class AppWorker extends Worker.Abstract {
@@ -22,7 +21,7 @@ export default class AppWorker extends Worker.Abstract {
     await this.command.output.wait(500);
     this.logger.write('watching for config updates...');
 
-    this.watcher = Filesystem.watch(Path.resolve(this.app.root, APP_CONFIG_FILENAME), {
+    this.watcher = Filesystem.watch(Path.resolve(this.app.root, this.app.configFilename), {
       persistent: true,
       ignoreInitial: true,
       awaitWriteFinish: {

--- a/packages/app/lib/cli/services/dev/workers/dev-session-worker.ts
+++ b/packages/app/lib/cli/services/dev/workers/dev-session-worker.ts
@@ -1,6 +1,6 @@
 import type { Cli } from '@youcan/cli-kit';
 import type { App, Manifest, ManifestFile } from '@/types';
-import { Env, Filesystem, Http, Path, Worker } from '@youcan/cli-kit';
+import { Env, Filesystem, Http, Worker } from '@youcan/cli-kit';
 import { buildManifest } from '@/cli/services/deploy/manifest';
 import { uploadMissingBlobs } from '@/cli/services/deploy/upload';
 import { ensureExtensionIds } from '@/cli/services/extensions';

--- a/packages/app/lib/cli/services/dev/workers/web-worker.test.ts
+++ b/packages/app/lib/cli/services/dev/workers/web-worker.test.ts
@@ -1,6 +1,6 @@
-import type { App, Web } from '@/types';
 import type { Cli } from '@youcan/cli-kit';
-import { System, Worker } from '@youcan/cli-kit';
+import type { App, Web } from '@/types';
+import { System } from '@youcan/cli-kit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import WebWorker from './web-worker';
 
@@ -65,6 +65,7 @@ describe('webWorker', () => {
         oauth: { client_id: 'id', scopes: [] },
       },
       webs: [],
+      configFilename: 'youcan.app.json',
       extensions: [],
       network_config: {
         app_port: 3001,

--- a/packages/app/lib/cli/services/dev/workers/web-worker.ts
+++ b/packages/app/lib/cli/services/dev/workers/web-worker.ts
@@ -1,6 +1,6 @@
 import type { App, Web } from '@/types';
-import { getAppEnvironmentVariables } from '@/cli/services/environment-variables';
 import { type Cli, type Services, System, Worker } from '@youcan/cli-kit';
+import { getAppEnvironmentVariables } from '@/cli/services/environment-variables';
 
 export default class WebWorker extends Worker.Abstract {
   private logger: Worker.Logger;

--- a/packages/app/lib/cli/services/extensions.ts
+++ b/packages/app/lib/cli/services/extensions.ts
@@ -1,23 +1,40 @@
-import type { App, ExtensionMetadata } from '@/types';
+import type { App, Extension, ExtensionMetadata } from '@/types';
 import { Env, Filesystem, Http, Path } from '@youcan/cli-kit';
-import { EXTENSION_CONFIG_FILENAME } from '@/constants';
+import { APP_CONFIG_FILENAME } from '@/constants';
 
 export async function ensureExtensionIds(app: App): Promise<void> {
+  const ids: Record<string, string> = { ...app.config.extension_ids };
+  const legacy = app.configFilename === APP_CONFIG_FILENAME;
+
   for (const extension of app.extensions) {
-    if (extension.config.id) {
-      continue;
+    const handle = extensionHandle(extension);
+    let id = ids[handle] ?? (legacy ? extension.config.id as string | undefined : undefined);
+
+    if (!id) {
+      const res = await Http.post<{ id: string; metadata: ExtensionMetadata }>(
+        `${Env.apiHostname()}/apps/${app.config.id}/extensions/create`,
+        { body: JSON.stringify({ ...extension.config, id: undefined }) },
+      );
+
+      id = res.id;
     }
 
-    const res = await Http.post<{ id: string; metadata: ExtensionMetadata }>(
-      `${Env.apiHostname()}/apps/${app.config.id}/extensions/create`,
-      { body: JSON.stringify({ ...extension.config }) },
-    );
-
-    extension.config.id = res.id;
-
-    await Filesystem.writeJsonFile(
-      Path.join(extension.root, EXTENSION_CONFIG_FILENAME),
-      { ...extension.config },
-    );
+    extension.config.id = id;
+    ids[handle] = id;
   }
+
+  if (JSON.stringify(ids) === JSON.stringify(app.config.extension_ids ?? {})) {
+    return;
+  }
+
+  app.config.extension_ids = ids;
+
+  const path = Path.join(app.root, app.configFilename);
+  const disk = await Filesystem.readJsonFile<Record<string, unknown>>(path);
+
+  await Filesystem.writeJsonFile(path, { ...disk, extension_ids: ids });
+}
+
+function extensionHandle(extension: Extension): string {
+  return (extension.config.handle as string | undefined) ?? Path.basename(extension.root);
 }

--- a/packages/app/lib/cli/services/generate/generate.ts
+++ b/packages/app/lib/cli/services/generate/generate.ts
@@ -1,6 +1,6 @@
 import type { ExtensionFlavor, ExtensionTemplateType, InitialAppConfig } from '@/types';
-import { EXTENSION_CONFIG_FILENAME } from '@/constants';
 import { Filesystem, Git, Path } from '@youcan/cli-kit';
+import { EXTENSION_CONFIG_FILENAME } from '@/constants';
 
 export async function ensureExtensionDirectoryExists(name: string) {
   const dir = Path.join(Path.cwd(), 'extensions', name);

--- a/packages/app/lib/constants.ts
+++ b/packages/app/lib/constants.ts
@@ -1,4 +1,8 @@
 export const APP_CONFIG_FILENAME = 'youcan.app.json';
+
+export function appConfigFilename(env?: string): string {
+  return env ? `youcan.app.${env}.json` : APP_CONFIG_FILENAME;
+}
 export const WEB_CONFIG_FILENAME = 'youcan.web.json';
 export const EXTENSION_CONFIG_FILENAME = 'youcan.extension.json';
 

--- a/packages/app/lib/types.ts
+++ b/packages/app/lib/types.ts
@@ -14,12 +14,19 @@ export type AppConfig = {
   app_url: string;
   redirect_urls: string[];
   webhooks?: AppWebhook[];
+  extension_ids?: Record<string, string>;
 
   oauth: {
     client_id: string;
     scopes: string[];
   };
 } & InitialAppConfig;
+
+export interface RemoteAppSummary {
+  id: string;
+  handle: string;
+  name: string;
+}
 
 export interface RemoteAppConfig {
   id: string;
@@ -85,6 +92,7 @@ export interface App {
   root: string;
   webs: Web[];
   config: AppConfig;
+  configFilename: string;
   remote_config?: RemoteAppConfig;
   network_config?: {
     app_url: string;

--- a/packages/app/lib/util/app-command.ts
+++ b/packages/app/lib/util/app-command.ts
@@ -1,11 +1,23 @@
 import type { Session } from '@youcan/cli-kit';
 import type { App, AppConfig, RemoteAppConfig } from '@/types';
+import { Flags } from '@oclif/core';
 import { Cli, Env, Filesystem, Http, Path } from '@youcan/cli-kit';
-import { APP_CONFIG_FILENAME } from '@/constants';
 
 export abstract class AppCommand extends Cli.Command {
+  static baseFlags = {
+    config: Flags.string({ char: 'c', description: 'Config environment, resolves youcan.app.<env>.json' }),
+  };
+
   protected app!: App;
   protected session!: Session.StoreSession;
+
+  public async fetchRemoteConfig(): Promise<RemoteAppConfig> {
+    const res = await Http.get<RemoteAppConfig>(`${Env.apiHostname()}/apps/${this.app.config.id}`);
+
+    this.app.remote_config = res;
+
+    return res;
+  }
 
   public async syncAppConfig(): Promise<App> {
     const created = this.app.config.id == null;
@@ -46,7 +58,7 @@ export abstract class AppCommand extends Cli.Command {
   }
 
   private async persistIdentity(res: RemoteAppConfig): Promise<void> {
-    const path = Path.join(this.app.root, APP_CONFIG_FILENAME);
+    const path = Path.join(this.app.root, this.app.configFilename);
     const disk = await Filesystem.readJsonFile<Partial<AppConfig>>(path).catch(() => ({}));
 
     await Filesystem.writeJsonFile(path, {

--- a/packages/app/lib/util/app-loader.ts
+++ b/packages/app/lib/util/app-loader.ts
@@ -1,17 +1,22 @@
 import type { App, AppConfig, Extension, ExtensionConfig, Web, WebConfig } from '@/types';
-import { APP_CONFIG_FILENAME, DEFAULT_EXTENSIONS_DIR, DEFAULT_WEBS_DIR, EXTENSION_CONFIG_FILENAME, WEB_CONFIG_FILENAME } from '@/constants';
 import { Filesystem, Path } from '@youcan/cli-kit';
+import { appConfigFilename, DEFAULT_EXTENSIONS_DIR, DEFAULT_WEBS_DIR, EXTENSION_CONFIG_FILENAME, WEB_CONFIG_FILENAME } from '@/constants';
 
-export async function load() {
-  const path = Path.resolve(Path.cwd(), APP_CONFIG_FILENAME);
+export async function load(env?: string) {
+  const filename = appConfigFilename(env);
+
+  const path = Path.resolve(Path.cwd(), filename);
   if (!await Filesystem.exists(path)) {
-    throw new Error(`app config not found at ${path}`);
+    throw new Error(env
+      ? `app config not found at ${path}, run \`youcan app config link ${env}\` to create it`
+      : `app config not found at ${path}`);
   }
 
   const config = await Filesystem.readJsonFile<AppConfig>(path);
 
   const app: App = {
     config,
+    configFilename: filename,
     webs: [],
     extensions: [],
     root: Path.cwd(),


### PR DESCRIPTION
youcan.app.<env>.json via --config on dev, deploy, release, versions, config pull, env show/pull; app config link; per-config extension ids; env commands read via GET instead of posting an update