### PR TITLE
fix --config flag registration, link seeds webhooks from base config

### DIFF
--- a/packages/app/lib/cli/commands/app/config/link.ts
+++ b/packages/app/lib/cli/commands/app/config/link.ts
@@ -1,7 +1,7 @@
-import type { RemoteAppConfig, RemoteAppSummary } from '@/types';
+import type { AppConfig, RemoteAppConfig, RemoteAppSummary } from '@/types';
 import { Args, Flags } from '@oclif/core';
 import { Color, Env, Filesystem, Http, Path, Session } from '@youcan/cli-kit';
-import { appConfigFilename } from '@/constants';
+import { APP_CONFIG_FILENAME, appConfigFilename } from '@/constants';
 import { AppCommand } from '@/util/app-command';
 
 export default class ConfigLink extends AppCommand {
@@ -29,12 +29,17 @@ export default class ConfigLink extends AppCommand {
 
     const filename = appConfigFilename(args.env);
 
+    const base = await Filesystem
+      .readJsonFile<Partial<AppConfig>>(Path.resolve(Path.cwd(), APP_CONFIG_FILENAME))
+      .catch(() => ({} as Partial<AppConfig>));
+
     await Filesystem.writeJsonFile(Path.resolve(Path.cwd(), filename), {
       name: remote.name,
       id: remote.id,
       handle: remote.handle,
       app_url: remote.app_url,
       redirect_urls: remote.redirect_urls,
+      webhooks: base.webhooks ?? [],
       oauth: {
         scopes: remote.scopes,
         client_id: remote.client_id,

--- a/packages/app/lib/cli/commands/app/config/pull.ts
+++ b/packages/app/lib/cli/commands/app/config/pull.ts
@@ -1,10 +1,14 @@
 import type { AppConfig, AppVersion, Manifest } from '@/types';
 import { Color, Env, Filesystem, Http, Path, Session } from '@youcan/cli-kit';
-import { AppCommand } from '@/util/app-command';
+import { AppCommand, configFlag } from '@/util/app-command';
 import { load } from '@/util/app-loader';
 
 export default class ConfigPull extends AppCommand {
   static description = 'Update the app config file from the active released version';
+
+  static flags = {
+    ...configFlag,
+  };
 
   async run() {
     const { flags } = await this.parse(ConfigPull);

--- a/packages/app/lib/cli/commands/app/deploy.ts
+++ b/packages/app/lib/cli/commands/app/deploy.ts
@@ -4,13 +4,14 @@ import { Env, Http, Session } from '@youcan/cli-kit';
 import { buildManifest } from '@/cli/services/deploy/manifest';
 import { uploadMissingBlobs } from '@/cli/services/deploy/upload';
 import { ensureExtensionIds } from '@/cli/services/extensions';
-import { AppCommand } from '@/util/app-command';
+import { AppCommand, configFlag } from '@/util/app-command';
 import { load } from '@/util/app-loader';
 
 export default class Deploy extends AppCommand {
   static description = 'Create a new app version and release it';
 
   static flags = {
+    ...configFlag,
     'message': Flags.string({ char: 'm', description: 'Version description' }),
     'version': Flags.string({ description: 'Version name, generated when omitted' }),
     'no-release': Flags.boolean({ description: 'Create the version without releasing it', default: false }),

--- a/packages/app/lib/cli/commands/app/dev.ts
+++ b/packages/app/lib/cli/commands/app/dev.ts
@@ -3,7 +3,7 @@ import process from 'node:process';
 import { Flags } from '@oclif/core';
 import { Env, Http, Services, Session, System, Tasks, UI } from '@youcan/cli-kit';
 import { bootAppWorker, bootDevSessionWorker, bootWebWorker } from '@/cli/services/dev/workers';
-import { AppCommand } from '@/util/app-command';
+import { AppCommand, configFlag } from '@/util/app-command';
 import { load } from '@/util/app-loader';
 
 interface Context {
@@ -15,6 +15,7 @@ class Dev extends AppCommand {
   static description = 'Run the app in dev mode';
 
   static flags = {
+    ...configFlag,
     'no-tunnel': Flags.boolean({
       description: 'Skip cloudflared tunnel and use localhost URL directly',
       default: false,

--- a/packages/app/lib/cli/commands/app/env/pull.ts
+++ b/packages/app/lib/cli/commands/app/env/pull.ts
@@ -1,13 +1,14 @@
 import { Flags } from '@oclif/core';
 import { Color, Filesystem, Path, Session, Tasks } from '@youcan/cli-kit';
 import { getAppEnvironmentVariables } from '@/cli/services/environment-variables';
-import { AppCommand } from '@/util/app-command';
+import { AppCommand, configFlag } from '@/util/app-command';
 import { load } from '@/util/app-loader';
 
 class EnvPull extends AppCommand {
   static description = 'Create or update a .env file with app environment variables';
 
   static flags = {
+    ...configFlag,
     'env-file': Flags.string({
       description: 'Path to the .env file to create or update',
       default: '.env',

--- a/packages/app/lib/cli/commands/app/env/show.ts
+++ b/packages/app/lib/cli/commands/app/env/show.ts
@@ -1,10 +1,14 @@
 import { Color, Session, Tasks } from '@youcan/cli-kit';
 import { getAppEnvironmentVariables } from '@/cli/services/environment-variables';
-import { AppCommand } from '@/util/app-command';
+import { AppCommand, configFlag } from '@/util/app-command';
 import { load } from '@/util/app-loader';
 
 class EnvShow extends AppCommand {
   static description = 'Display app environment variables';
+
+  static flags = {
+    ...configFlag,
+  };
 
   async run(): Promise<any> {
     const { flags } = await this.parse(EnvShow);

--- a/packages/app/lib/cli/commands/app/release.ts
+++ b/packages/app/lib/cli/commands/app/release.ts
@@ -1,13 +1,14 @@
 import type { AppVersion } from '@/types';
 import { Flags } from '@oclif/core';
 import { Env, Http, Session } from '@youcan/cli-kit';
-import { AppCommand } from '@/util/app-command';
+import { AppCommand, configFlag } from '@/util/app-command';
 import { load } from '@/util/app-loader';
 
 export default class Release extends AppCommand {
   static description = 'Release an existing app version';
 
   static flags = {
+    ...configFlag,
     version: Flags.string({ description: 'Version number or name to release', required: true }),
   };
 

--- a/packages/app/lib/cli/commands/app/versions.ts
+++ b/packages/app/lib/cli/commands/app/versions.ts
@@ -1,10 +1,14 @@
 import type { AppVersion } from '@/types';
 import { Env, Http, Session } from '@youcan/cli-kit';
-import { AppCommand } from '@/util/app-command';
+import { AppCommand, configFlag } from '@/util/app-command';
 import { load } from '@/util/app-loader';
 
 export default class Versions extends AppCommand {
   static description = 'List the app versions';
+
+  static flags = {
+    ...configFlag,
+  };
 
   async run() {
     const { flags } = await this.parse(Versions);

--- a/packages/app/lib/util/app-command.ts
+++ b/packages/app/lib/util/app-command.ts
@@ -3,11 +3,11 @@ import type { App, AppConfig, RemoteAppConfig } from '@/types';
 import { Flags } from '@oclif/core';
 import { Cli, Env, Filesystem, Http, Path } from '@youcan/cli-kit';
 
-export abstract class AppCommand extends Cli.Command {
-  static baseFlags = {
-    config: Flags.string({ char: 'c', description: 'Config environment, resolves youcan.app.<env>.json' }),
-  };
+export const configFlag = {
+  config: Flags.string({ char: 'c', description: 'Config environment, resolves youcan.app.<env>.json' }),
+};
 
+export abstract class AppCommand extends Cli.Command {
   protected app!: App;
   protected session!: Session.StoreSession;
 


### PR DESCRIPTION
oclif baseFlags merge via static setters that ES2022 class fields bypass, so the flag never registered