### PR TITLE
dev: bootstrap app_url on apps that have none

### DIFF
--- a/packages/app/lib/cli/commands/app/deploy.ts
+++ b/packages/app/lib/cli/commands/app/deploy.ts
@@ -4,6 +4,7 @@ import { Env, Http, Session } from '@youcan/cli-kit';
 import { buildManifest } from '@/cli/services/deploy/manifest';
 import { uploadMissingBlobs } from '@/cli/services/deploy/upload';
 import { ensureExtensionIds } from '@/cli/services/extensions';
+import { TUNNEL_HOSTS } from '@/constants';
 import { AppCommand, configFlag } from '@/util/app-command';
 import { load } from '@/util/app-loader';
 
@@ -71,8 +72,7 @@ export default class Deploy extends AppCommand {
       );
     }
 
-    const tunnels = ['trycloudflare.com', 'ngrok-free.app', 'ngrok.io'];
-    if (url && tunnels.some(host => url.includes(host))) {
+    if (url && TUNNEL_HOSTS.some(host => url.includes(host))) {
       this.output.error(
         `The app url points at a dev tunnel (${url}), releasing would break the live app. Fix youcan.app.json or pass --force.`,
       );

--- a/packages/app/lib/cli/services/dev/workers/web-worker.test.ts
+++ b/packages/app/lib/cli/services/dev/workers/web-worker.test.ts
@@ -142,6 +142,31 @@ describe('webWorker', () => {
     });
   });
 
+  describe('boot', () => {
+    it('keeps real redirect urls and prunes stale tunnel ones', async () => {
+      mockApp.config.redirect_urls = [
+        'https://myapp.example.com/auth/callback',
+        'https://old.trycloudflare.com/auth/callback',
+      ];
+
+      await webWorker.boot();
+
+      expect(mockApp.config.redirect_urls).toEqual([
+        'http://localhost:3001/auth/callback',
+        'https://myapp.example.com/auth/callback',
+      ]);
+      expect(mockApp.config.app_url).toBe('http://localhost:3001');
+    });
+
+    it('defaults to the callback path when no redirect urls exist', async () => {
+      mockApp.config.redirect_urls = [];
+
+      await webWorker.boot();
+
+      expect(mockApp.config.redirect_urls).toEqual(['http://localhost:3001/auth/callback']);
+    });
+  });
+
   describe('run', () => {
     it('should spawn the web command detached with env computed from app', async () => {
       const child = Object.assign(Promise.resolve(), { pid: 42, killed: false });

--- a/packages/app/lib/cli/services/dev/workers/web-worker.ts
+++ b/packages/app/lib/cli/services/dev/workers/web-worker.ts
@@ -2,6 +2,7 @@ import type { App, Web } from '@/types';
 import process from 'node:process';
 import { type Cli, type Services, System, Worker } from '@youcan/cli-kit';
 import { getAppEnvironmentVariables } from '@/cli/services/environment-variables';
+import { TUNNEL_HOSTS } from '@/constants';
 
 export default class WebWorker extends Worker.Abstract {
   private logger: Worker.Logger;
@@ -53,12 +54,21 @@ export default class WebWorker extends Worker.Abstract {
 
     const appUrl = this.app.network_config.app_url;
 
+    const ephemeral = [...TUNNEL_HOSTS, 'localhost', '127.0.0.1'];
+    const existing = this.app.config.redirect_urls ?? [];
+    const kept = existing.filter(url => !ephemeral.some(host => url.includes(host)));
+
+    const paths = new Set(existing.map(url => new URL(url).pathname));
+    if (!paths.size) {
+      paths.add('/auth/callback');
+    }
+
+    const tunneled = [...paths].map(path => new URL(path, appUrl).toString());
+
     this.app.config = {
       ...this.app.config,
       app_url: appUrl,
-      redirect_urls: this.app.config.redirect_urls?.length > 0
-        ? this.app.config.redirect_urls.map(r => new URL(new URL(r).pathname, appUrl).toString())
-        : [new URL('/auth/callback', appUrl).toString()],
+      redirect_urls: [...new Set([...tunneled, ...kept])].slice(0, 5),
     };
   }
 

--- a/packages/app/lib/constants.ts
+++ b/packages/app/lib/constants.ts
@@ -8,3 +8,5 @@ export const EXTENSION_CONFIG_FILENAME = 'youcan.extension.json';
 
 export const DEFAULT_WEBS_DIR = '.';
 export const DEFAULT_EXTENSIONS_DIR = 'extensions/';
+
+export const TUNNEL_HOSTS = ['trycloudflare.com', 'ngrok-free.app', 'ngrok.io'];

--- a/packages/app/lib/util/app-command.test.ts
+++ b/packages/app/lib/util/app-command.test.ts
@@ -4,11 +4,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppCommand } from './app-command';
 
 const post = vi.fn();
+const get = vi.fn();
 
 vi.mock('@youcan/cli-kit', () => ({
   Cli: { Command: class {} },
   Env: { apiHostname: () => 'api.test' },
-  Http: { post: (...args: unknown[]) => post(...args) },
+  Http: {
+    post: (...args: unknown[]) => post(...args),
+    get: (...args: unknown[]) => get(...args),
+  },
   Filesystem: {
     readJsonFile: vi.fn().mockResolvedValue({}),
     writeJsonFile: vi.fn(),
@@ -46,6 +50,7 @@ describe('syncAppConfig', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     post.mockResolvedValue(remote);
+    get.mockResolvedValue(remote);
 
     command = new TestCommand([], {} as Config);
     (command as any).session = { access_token: 'token' };
@@ -83,6 +88,23 @@ describe('syncAppConfig', () => {
 
     expect(app.config.app_url).toBe(remote.app_url);
     expect(app.config.id).toBe(remote.id);
+  });
+
+  it('bootstraps app_url on update when the remote app has none', async () => {
+    get.mockResolvedValue({ ...remote, app_url: null });
+
+    (command as any).app = makeApp({
+      id: 'app_1',
+      name: 'Test App',
+      app_url: 'https://tunnel.trycloudflare.com',
+      redirect_urls: ['https://tunnel.trycloudflare.com/auth/callback'],
+    });
+
+    await command.syncAppConfig();
+
+    const [endpoint, options] = post.mock.calls[0];
+    expect(endpoint).toBe('api.test/apps/app_1/update');
+    expect(JSON.parse(options.body).app_url).toBe('https://tunnel.trycloudflare.com');
   });
 
   it('still registers redirect urls on update', async () => {

--- a/packages/app/lib/util/app-command.ts
+++ b/packages/app/lib/util/app-command.ts
@@ -26,12 +26,16 @@ export abstract class AppCommand extends Cli.Command {
       ? `${Env.apiHostname()}/apps/create`
       : `${Env.apiHostname()}/apps/${this.app.config.id}/update`;
 
+    const sendUrl = created || (
+      !!this.app.config.app_url && !(await this.fetchRemoteConfig()).app_url
+    );
+
     const res = await Http.post<RemoteAppConfig>(endpoint, {
       headers: { Authorization: `Bearer ${this.session.access_token}` },
       body: JSON.stringify({
         name: this.app.config.name,
         redirect_urls: this.app.config.redirect_urls,
-        ...(created ? { app_url: this.app.config.app_url } : {}),
+        ...(sendUrl ? { app_url: this.app.config.app_url } : {}),
       }),
     });
 


### PR DESCRIPTION
linked extension-only apps kept a null app_url forever, update now sends the tunnel url only when the remote has none